### PR TITLE
Move error structs to private

### DIFF
--- a/app_error.go
+++ b/app_error.go
@@ -44,8 +44,8 @@ type AppError interface {
 	Build(Language, ...InfoBuilderOption) *InfoBuilderResult
 }
 
-// DefaultAppError implements AppError interface
-type DefaultAppError struct {
+// defaultAppError implements AppError interface
+type defaultAppError struct {
 	err           error
 	cause         error
 	params        map[string]any
@@ -58,13 +58,13 @@ type DefaultAppError struct {
 }
 
 // Error implements `error` interface
-func (e *DefaultAppError) Error() string {
+func (e *defaultAppError) Error() string {
 	return e.err.Error()
 }
 
 // Is implementation used by errors.Is().
 // This function returns true if either the inner error or the cause satisfies.
-func (e *DefaultAppError) Is(err error) bool {
+func (e *defaultAppError) Is(err error) bool {
 	if errors.Is(e.err, err) {
 		return true
 	}
@@ -75,50 +75,50 @@ func (e *DefaultAppError) Is(err error) bool {
 }
 
 // Unwrap implementation used by errors.Unwrap() and errors.Is()
-func (e *DefaultAppError) Unwrap() error {
+func (e *defaultAppError) Unwrap() error {
 	return e.err
 }
 
-func (e *DefaultAppError) Params() map[string]any {
+func (e *defaultAppError) Params() map[string]any {
 	return e.params
 }
 
-func (e *DefaultAppError) TransParams() map[string]string {
+func (e *defaultAppError) TransParams() map[string]string {
 	return e.transParams
 }
 
-func (e *DefaultAppError) Cause() error {
+func (e *defaultAppError) Cause() error {
 	return e.cause
 }
 
-func (e *DefaultAppError) Debug() string {
+func (e *defaultAppError) Debug() string {
 	return e.debug
 }
 
-func (e *DefaultAppError) CustomConfig() *ErrorConfig {
+func (e *defaultAppError) CustomConfig() *ErrorConfig {
 	return e.customConfig
 }
 
-func (e *DefaultAppError) CustomBuilder() InfoBuilderFunc {
+func (e *defaultAppError) CustomBuilder() InfoBuilderFunc {
 	return e.customBuilder
 }
 
-func (e *DefaultAppError) WithParam(k string, v any) AppError {
+func (e *defaultAppError) WithParam(k string, v any) AppError {
 	e.params[k] = v
 	return e
 }
 
-func (e *DefaultAppError) WithTransParam(k string, v string) AppError {
+func (e *defaultAppError) WithTransParam(k string, v string) AppError {
 	e.transParams[k] = v
 	return e
 }
 
-func (e *DefaultAppError) WithCause(cause error) AppError {
+func (e *defaultAppError) WithCause(cause error) AppError {
 	e.cause = cause
 	return e
 }
 
-func (e *DefaultAppError) WithDebug(format string, args ...any) AppError {
+func (e *defaultAppError) WithDebug(format string, args ...any) AppError {
 	if !globalConfig.Debug {
 		return e
 	}
@@ -131,18 +131,18 @@ func (e *DefaultAppError) WithDebug(format string, args ...any) AppError {
 	return e
 }
 
-func (e *DefaultAppError) WithCustomConfig(cfg *ErrorConfig) AppError {
+func (e *defaultAppError) WithCustomConfig(cfg *ErrorConfig) AppError {
 	e.customConfig = cfg
 	return e
 }
 
-func (e *DefaultAppError) WithCustomBuilder(infoBuilder InfoBuilderFunc) AppError {
+func (e *defaultAppError) WithCustomBuilder(infoBuilder InfoBuilderFunc) AppError {
 	e.customBuilder = infoBuilder
 	return e
 }
 
 // Config returns the custom config if set, otherwise returns the global mapping one
-func (e *DefaultAppError) Config() *ErrorConfig {
+func (e *defaultAppError) Config() *ErrorConfig {
 	if e.disallowGlobalConfigMapping {
 		return e.customConfig
 	}
@@ -153,7 +153,7 @@ func (e *DefaultAppError) Config() *ErrorConfig {
 }
 
 // BuildConfig builds config for building info from the error
-func (e *DefaultAppError) BuildConfig(lang Language, options ...InfoBuilderOption) *InfoBuilderConfig {
+func (e *defaultAppError) BuildConfig(lang Language, options ...InfoBuilderOption) *InfoBuilderConfig {
 	errCfg := e.Config()
 	if errCfg == nil {
 		errCfg = &ErrorConfig{}
@@ -179,12 +179,12 @@ func (e *DefaultAppError) BuildConfig(lang Language, options ...InfoBuilderOptio
 }
 
 // Build builds error info
-func (e *DefaultAppError) Build(lang Language, options ...InfoBuilderOption) *InfoBuilderResult {
+func (e *defaultAppError) Build(lang Language, options ...InfoBuilderOption) *InfoBuilderResult {
 	return e.build(e.BuildConfig(lang, options...))
 }
 
 // build builds error info using the given building config
-func (e *DefaultAppError) build(buildCfg *InfoBuilderConfig) *InfoBuilderResult {
+func (e *defaultAppError) build(buildCfg *InfoBuilderConfig) *InfoBuilderResult {
 	if buildCfg.InfoBuilderFunc != nil {
 		return buildCfg.InfoBuilderFunc(e, buildCfg)
 	}
@@ -217,7 +217,7 @@ func (e *DefaultAppError) build(buildCfg *InfoBuilderConfig) *InfoBuilderResult 
 }
 
 // buildMessage builds detailed message of the error
-func (e *DefaultAppError) buildMessage(buildCfg *InfoBuilderConfig, result *InfoBuilderResult) (msg, title string) {
+func (e *defaultAppError) buildMessage(buildCfg *InfoBuilderConfig, result *InfoBuilderResult) (msg, title string) {
 	title = buildCfg.ErrorConfig.Title
 	if title == "" {
 		title = http.StatusText(result.ErrorInfo.Status)
@@ -257,7 +257,7 @@ func (e *DefaultAppError) buildMessage(buildCfg *InfoBuilderConfig, result *Info
 }
 
 // buildParams builds param map from params and translating params
-func (e *DefaultAppError) buildParams(buildCfg *InfoBuilderConfig, result *InfoBuilderResult) map[string]any {
+func (e *defaultAppError) buildParams(buildCfg *InfoBuilderConfig, result *InfoBuilderResult) map[string]any {
 	params := e.params
 	for k, v := range e.transParams {
 		if translated, err := buildCfg.TranslationFunc(buildCfg.Language, v, nil); err != nil {
@@ -270,9 +270,9 @@ func (e *DefaultAppError) buildParams(buildCfg *InfoBuilderConfig, result *InfoB
 	return params
 }
 
-// newDefaultAppError creates *DefaultAppError
-func newDefaultAppError(err error) *DefaultAppError {
-	return &DefaultAppError{
+// newDefaultAppError creates *defaultAppError
+func newDefaultAppError(err error) *defaultAppError {
+	return &defaultAppError{
 		err:         Wrap(err),
 		params:      map[string]any{},
 		transParams: map[string]string{},

--- a/multi_error.go
+++ b/multi_error.go
@@ -5,23 +5,24 @@ import (
 	"strings"
 )
 
+// MultiError can handle multiple underlying AppErrors
 type MultiError interface {
 	AppError
 
 	InnerErrors() AppErrors
 }
 
-type DefaultMultiError struct {
-	*DefaultAppError
+type defaultMultiError struct {
+	*defaultAppError
 }
 
 // Unwrap - implementation used by errors.Is
-func (e *DefaultMultiError) Unwrap() []error {
+func (e *defaultMultiError) Unwrap() []error {
 	return e.InnerErrors().Unwrap()
 }
 
 // InnerErrors returns all wrapped errors as AppErrors
-func (e *DefaultMultiError) InnerErrors() AppErrors {
+func (e *defaultMultiError) InnerErrors() AppErrors {
 	err := e.err
 	for {
 		if inErrs, ok := err.(AppErrors); ok { //nolint:errorlint
@@ -34,43 +35,43 @@ func (e *DefaultMultiError) InnerErrors() AppErrors {
 }
 
 // WithParam - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithParam(k string, v any) AppError {
-	_ = e.DefaultAppError.WithParam(k, v)
+func (e *defaultMultiError) WithParam(k string, v any) AppError {
+	_ = e.defaultAppError.WithParam(k, v)
 	return e
 }
 
 // WithTransParam - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithTransParam(k string, v string) AppError {
-	_ = e.DefaultAppError.WithTransParam(k, v)
+func (e *defaultMultiError) WithTransParam(k string, v string) AppError {
+	_ = e.defaultAppError.WithTransParam(k, v)
 	return e
 }
 
 // WithCause - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithCause(cause error) AppError {
-	_ = e.DefaultAppError.WithCause(cause)
+func (e *defaultMultiError) WithCause(cause error) AppError {
+	_ = e.defaultAppError.WithCause(cause)
 	return e
 }
 
 // WithDebug - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithDebug(format string, args ...any) AppError {
-	_ = e.DefaultAppError.WithDebug(format, args...)
+func (e *defaultMultiError) WithDebug(format string, args ...any) AppError {
+	_ = e.defaultAppError.WithDebug(format, args...)
 	return e
 }
 
 // WithCustomConfig - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithCustomConfig(cfg *ErrorConfig) AppError {
-	_ = e.DefaultAppError.WithCustomConfig(cfg)
+func (e *defaultMultiError) WithCustomConfig(cfg *ErrorConfig) AppError {
+	_ = e.defaultAppError.WithCustomConfig(cfg)
 	return e
 }
 
 // WithCustomBuilder - re-defines to make sure the returning points to this error object
-func (e *DefaultMultiError) WithCustomBuilder(infoBuilder InfoBuilderFunc) AppError {
-	_ = e.DefaultAppError.WithCustomBuilder(infoBuilder)
+func (e *defaultMultiError) WithCustomBuilder(infoBuilder InfoBuilderFunc) AppError {
+	_ = e.defaultAppError.WithCustomBuilder(infoBuilder)
 	return e
 }
 
 // Build implements Build function
-func (e *DefaultMultiError) Build(lang Language, options ...InfoBuilderOption) *InfoBuilderResult {
+func (e *defaultMultiError) Build(lang Language, options ...InfoBuilderOption) *InfoBuilderResult {
 	buildCfg := e.BuildConfig(lang, options...)
 	buildResult := e.build(buildCfg)
 	errInfo := buildResult.ErrorInfo
@@ -102,8 +103,8 @@ func NewMultiError(errs ...AppError) MultiError {
 	if len(errs) == 0 {
 		return nil
 	}
-	e := &DefaultMultiError{
-		DefaultAppError: newDefaultAppError(AppErrors(errs)),
+	e := &defaultMultiError{
+		defaultAppError: newDefaultAppError(AppErrors(errs)),
 	}
 	// MultiError does not allow using global config mapping
 	// If you need to set custom config, sets via the field `customConfig`

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -15,7 +15,7 @@ var (
 )
 
 type testVldErr struct {
-	*DefaultAppError
+	*defaultAppError
 }
 
 func (e *testVldErr) Build(lang Language, options ...InfoBuilderOption) *InfoBuilderResult {
@@ -78,9 +78,9 @@ func Test_ValidationError(t *testing.T) {
 
 		assert.Nil(t, NewValidationError())
 		vldErr := NewValidationError(
-			&testVldErr{DefaultAppError: NewAppError(err3rdPartyVld1).(*DefaultAppError)},
-			&testVldErr{DefaultAppError: NewAppError(err3rdPartyVld2).(*DefaultAppError)},
-			&testVldErr{DefaultAppError: NewAppError(err3rdPartyVld3).(*DefaultAppError)},
+			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld1).(*defaultAppError)},
+			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld2).(*defaultAppError)},
+			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld3).(*defaultAppError)},
 		)
 
 		result := vldErr.Build(LanguageEn)


### PR DESCRIPTION
## Why

Seems like we don't need to expose them.