### PR TITLE
Change Language type to any

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,25 +4,6 @@ import (
 	"net/http"
 )
 
-type Language string
-
-const (
-	LanguageEn = Language("en")
-	LanguageFr = Language("fr")
-	LanguageDe = Language("de")
-	LanguageEs = Language("es")
-	LanguageIt = Language("it")
-	LanguagePt = Language("pt")
-	LanguageRu = Language("ru")
-	LanguageZh = Language("zh")
-	LanguageJa = Language("ja")
-	LanguageKo = Language("ko")
-	LanguageAr = Language("ar")
-	LanguageHi = Language("hi")
-)
-
-type TranslationFunc func(lang Language, key string, params map[string]any) (string, error)
-
 // Config to provide global config for the library
 type Config struct {
 	// Debug flag indicates debug mode (default: `false`).
@@ -37,6 +18,8 @@ type Config struct {
 	// If WrapFunc is set with custom value, this config has no effect.
 	MaxStackDepth int
 
+	// DefaultLanguage default language (default: `LanguageEn`)
+	DefaultLanguage Language
 	// TranslationFunc function to translate message into a specific language (default: `nil`)
 	TranslationFunc TranslationFunc
 	// FallbackToErrorContentOnMissingTranslation indicates fallback to error content
@@ -58,6 +41,9 @@ func (cfg *Config) setDefault() {
 	if cfg.MaxStackDepth == 0 {
 		cfg.MaxStackDepth = defaultMaxStackDepth
 	}
+	if cfg.DefaultLanguage == nil {
+		cfg.DefaultLanguage = defaultLanguage
+	}
 	if cfg.MultiErrorSeparator == "" {
 		cfg.MultiErrorSeparator = defaultErrorSeparator
 	}
@@ -74,6 +60,7 @@ func (cfg *Config) setDefault() {
 
 const (
 	defaultMaxStackDepth         = 50
+	defaultLanguage              = LanguageEn
 	defaultErrorSeparator        = "\n"
 	defaultErrorStatus           = http.StatusInternalServerError
 	defaultValidationErrorStatus = http.StatusBadRequest
@@ -85,6 +72,7 @@ var (
 		Debug:         false,
 		MaxStackDepth: defaultMaxStackDepth,
 
+		DefaultLanguage: defaultLanguage,
 		FallbackToErrorContentOnMissingTranslation: true,
 		MultiErrorSeparator:                        defaultErrorSeparator,
 

--- a/config_test.go
+++ b/config_test.go
@@ -12,6 +12,7 @@ func Test_Config_setDefault(t *testing.T) {
 
 	assert.Nil(t, config.WrapFunc)
 	assert.Equal(t, defaultMaxStackDepth, config.MaxStackDepth)
+	assert.Equal(t, defaultLanguage, config.DefaultLanguage)
 	assert.Nil(t, config.TranslationFunc)
 	assert.False(t, config.FallbackToErrorContentOnMissingTranslation)
 	assert.Equal(t, defaultErrorSeparator, config.MultiErrorSeparator)

--- a/data_test.go
+++ b/data_test.go
@@ -15,6 +15,7 @@ var (
 var (
 	okConfig = &Config{
 		Debug:           true,
+		DefaultLanguage: LanguageEn,
 		TranslationFunc: testTranslateOK,
 		FallbackToErrorContentOnMissingTranslation: true,
 		MultiErrorSeparator:                        ". ",
@@ -22,6 +23,7 @@ var (
 
 	noStackTraceConfig = &Config{
 		Debug:           true,
+		DefaultLanguage: LanguageEn,
 		WrapFunc:        func(err error) error { return err },
 		TranslationFunc: testTranslateOK,
 		FallbackToErrorContentOnMissingTranslation: true,
@@ -30,6 +32,7 @@ var (
 
 	failedTransConfig = &Config{
 		Debug:           true,
+		DefaultLanguage: LanguageEn,
 		TranslationFunc: testTranslateFail,
 		FallbackToErrorContentOnMissingTranslation: true,
 		MultiErrorSeparator:                        ". ",
@@ -37,6 +40,7 @@ var (
 
 	notransConfig = &Config{
 		Debug:           true,
+		DefaultLanguage: LanguageEn,
 		TranslationFunc: nil,
 		FallbackToErrorContentOnMissingTranslation: true,
 		MultiErrorSeparator:                        ". ",
@@ -44,6 +48,7 @@ var (
 
 	nonDebugConfig = &Config{
 		Debug:           false,
+		DefaultLanguage: LanguageEn,
 		TranslationFunc: testTranslateOK,
 		FallbackToErrorContentOnMissingTranslation: true,
 		MultiErrorSeparator:                        ". ",

--- a/localization.go
+++ b/localization.go
@@ -1,0 +1,23 @@
+package goapperrors
+
+// Language represents a language.
+// Language values can be anything and can be set by client code.
+// For example, Language("string") or Language(language.Tag from "golang.org/x/text/language").
+type Language any
+
+const (
+	LanguageEn = "en"
+	LanguageFr = "fr"
+	LanguageDe = "de"
+	LanguageEs = "es"
+	LanguageIt = "it"
+	LanguagePt = "pt"
+	LanguageRu = "ru"
+	LanguageZh = "zh"
+	LanguageJa = "ja"
+	LanguageKo = "ko"
+	LanguageAr = "ar"
+	LanguageHi = "hi"
+)
+
+type TranslationFunc func(lang Language, key string, params map[string]any) (string, error)


### PR DESCRIPTION
## Why

- Using `any` for language type can be easier for user to pass any value and get it back in the translate function.