### PR TITLE
Change log level type

### DIFF
--- a/error_config.go
+++ b/error_config.go
@@ -5,15 +5,15 @@ import "errors"
 // LogLevel represents log level set for an error.
 // You can use LogLevel to report the level of an error to external
 // services such as Sentry or Rollbar.
-type LogLevel int8
+type LogLevel string
 
 const (
-	LogLevelNone  LogLevel = iota
-	LogLevelDebug LogLevel = iota
-	LogLevelInfo  LogLevel = iota
-	LogLevelWarn  LogLevel = iota
-	LogLevelError LogLevel = iota
-	LogLevelFatal LogLevel = iota
+	LogLevelNone  LogLevel = ""
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warning"
+	LogLevelError LogLevel = "error"
+	LogLevelFatal LogLevel = "fatal"
 )
 
 // ErrorConfig configuration of an error to be used when build error info

--- a/main.go
+++ b/main.go
@@ -46,8 +46,8 @@ func Add(err error, cfg *ErrorConfig) error {
 //
 // Example:
 //
-// var ErrTokenInvalid = Create("ErrTokenInvalid", &ErrorConfig{Status: http.StatusUnauthorized})
-// var ErrNoPermission = Create("ErrNoPermission", &ErrorConfig{Status: http.StatusForbidden})
+//	var ErrTokenInvalid = Create("ErrTokenInvalid", &ErrorConfig{Status: http.StatusUnauthorized})
+//	var ErrNoPermission = Create("ErrNoPermission", &ErrorConfig{Status: http.StatusForbidden})
 func Create(code string, cfg *ErrorConfig) error {
 	if code == "" || cfg == nil {
 		panic("error key and config must not be nil")


### PR DESCRIPTION
## Why

- Using string can be easier to match with other services.