### PR TITLE
Refactor: rename NewAppError

### DIFF
--- a/app_error.go
+++ b/app_error.go
@@ -286,8 +286,8 @@ func newDefaultAppError(err error) *defaultAppError {
 	}
 }
 
-// NewAppError creates an AppError containing the given error
-func NewAppError(err error) AppError {
+// New creates an AppError containing the given error
+func New(err error) AppError {
 	if err == nil {
 		return nil
 	}

--- a/app_error_test.go
+++ b/app_error_test.go
@@ -11,9 +11,9 @@ import (
 func Test_NewAppError(t *testing.T) {
 	initConfig(okConfig)
 
-	ae1 := NewAppError(nil)
-	ae2 := NewAppError(errTest1)
-	ae3 := NewAppError(ae2)
+	ae1 := New(nil)
+	ae2 := New(errTest1)
+	ae3 := New(ae2)
 	ae4 := fmt.Errorf("%w", ae3)
 	ae5 := errors.Join(ae4, ae3, errTest2)
 
@@ -35,7 +35,7 @@ func Test_AppError_Common(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -54,7 +54,7 @@ func Test_AppError_Common(t *testing.T) {
 	t.Run("success: extending debug message", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithDebug("blah blah")
 
@@ -66,7 +66,7 @@ func Test_AppError_Common(t *testing.T) {
 	t.Run("success: non-debug mode", func(t *testing.T) {
 		initConfig(nonDebugConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithCause(errTest3)
 
@@ -81,7 +81,7 @@ func Test_AppError_Build(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -112,13 +112,13 @@ func Test_AppError_Build(t *testing.T) {
 			Code:   "ErrCustom",
 		})()
 
-		ae1 := NewAppError(errTest1).
+		ae1 := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
 			WithTransParam("kk1", "vv1").
 			WithCause(errTest2)
-		ae2 := NewAppError(errTest2).
+		ae2 := New(errTest2).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
 			WithTransParam("kk1", "vv1")
@@ -157,7 +157,7 @@ func Test_AppError_Build(t *testing.T) {
 			TransKey: "Trans123",
 		})()
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -197,7 +197,7 @@ func Test_AppError_Build(t *testing.T) {
 			}
 		}
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -240,7 +240,7 @@ func Test_AppError_Build(t *testing.T) {
 	t.Run("success: fails to translate but no fallback to error string", func(t *testing.T) {
 		initConfig(failedTransConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -262,7 +262,7 @@ func Test_AppError_Build(t *testing.T) {
 	t.Run("success: fails to translate but fallback to error string", func(t *testing.T) {
 		initConfig(failedTransConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithDebug("debug: %v", 123).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
@@ -284,7 +284,7 @@ func Test_AppError_Build(t *testing.T) {
 	t.Run("success: translation function unset", func(t *testing.T) {
 		initConfig(notransConfig)
 
-		ae := NewAppError(errTest1).
+		ae := New(errTest1).
 			WithParam("k1", "v1").
 			WithParam("k2", "v2").
 			WithTransParam("kk1", "vv1")

--- a/app_errors_test.go
+++ b/app_errors_test.go
@@ -10,8 +10,8 @@ import (
 func Test_AppErrorSlice(t *testing.T) {
 	initConfig(okConfig)
 
-	ae1 := NewAppError(errTest1)
-	ae2 := NewAppError(ae1)
+	ae1 := New(errTest1)
+	ae2 := New(ae1)
 	aeSlice := AppErrors{ae1, ae2}
 
 	assert.ErrorIs(t, aeSlice, errTest1)

--- a/main.go
+++ b/main.go
@@ -83,5 +83,5 @@ func Build(err error, lang Language, options ...InfoBuilderOption) *InfoBuilderR
 			break
 		}
 	}
-	return NewAppError(err).Build(lang, options...)
+	return New(err).Build(lang, options...)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -60,8 +60,8 @@ func Test_Build(t *testing.T) {
 	t.Run("builds direct app errors", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae1 := NewAppError(errTest1)
-		ae2 := NewMultiError(NewAppError(errTest1), NewAppError(errTest2)).
+		ae1 := New(errTest1)
+		ae2 := NewMultiError(New(errTest1), New(errTest2)).
 			WithCustomConfig(&ErrorConfig{
 				Status: 1234,
 				Code:   "Err1234",
@@ -86,8 +86,8 @@ func Test_Build(t *testing.T) {
 	t.Run("builds indirect app errors", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae1 := NewAppError(errTest1)
-		ae2 := NewMultiError(NewAppError(errTest1), NewAppError(errTest2)).
+		ae1 := New(errTest1)
+		ae2 := NewMultiError(New(errTest1), New(errTest2)).
 			WithCustomConfig(&ErrorConfig{
 				Status: 1234,
 				Code:   "Err1234",

--- a/multi_error_test.go
+++ b/multi_error_test.go
@@ -10,8 +10,8 @@ func Test_MultiError_Common(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae1 := NewAppError(errTest1)
-		ae2 := NewAppError(errTest2)
+		ae1 := New(errTest1)
+		ae2 := New(errTest2)
 		me1 := NewMultiError()
 		me2 := AsMultiError(NewMultiError(ae1).
 			WithParam("k1", "v1").
@@ -50,8 +50,8 @@ func Test_MultiError_Build(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		initConfig(okConfig)
 
-		ae1 := NewAppError(errTest1)
-		ae2 := NewAppError(errTest2)
+		ae1 := New(errTest1)
+		ae2 := New(errTest2)
 		me1 := AsMultiError(NewMultiError(ae1))
 		me2 := AsMultiError(NewMultiError(ae1, ae2).
 			WithCustomConfig(&ErrorConfig{
@@ -87,8 +87,8 @@ func Test_MultiError_Build(t *testing.T) {
 			Code:   "Err1234",
 		})()
 
-		ae1 := NewAppError(errTest1)
-		ae2 := NewAppError(errTest2)
+		ae1 := New(errTest1)
+		ae2 := New(errTest2)
 		me1 := AsMultiError(NewMultiError(ae1, ae2).
 			WithCustomConfig(&ErrorConfig{
 				Status:   1234,

--- a/validation_error.go
+++ b/validation_error.go
@@ -21,7 +21,7 @@ func NewValidationErrorWithInfoBuilder(infoBuilder InfoBuilderFunc, errs ...erro
 	}
 	appErrs := make(AppErrors, 0, len(errs))
 	for _, e := range errs {
-		appErrs = append(appErrs, NewAppError(e).WithCustomBuilder(infoBuilder))
+		appErrs = append(appErrs, New(e).WithCustomBuilder(infoBuilder))
 	}
 	return NewValidationError(appErrs...)
 }

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -78,9 +78,9 @@ func Test_ValidationError(t *testing.T) {
 
 		assert.Nil(t, NewValidationError())
 		vldErr := NewValidationError(
-			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld1).(*defaultAppError)},
-			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld2).(*defaultAppError)},
-			&testVldErr{defaultAppError: NewAppError(err3rdPartyVld3).(*defaultAppError)},
+			&testVldErr{defaultAppError: New(err3rdPartyVld1).(*defaultAppError)},
+			&testVldErr{defaultAppError: New(err3rdPartyVld2).(*defaultAppError)},
+			&testVldErr{defaultAppError: New(err3rdPartyVld3).(*defaultAppError)},
 		)
 
 		result := vldErr.Build(LanguageEn)


### PR DESCRIPTION
# Why

- As AppError is the core type of the lib, then just `New` is enough.